### PR TITLE
Fix an increment bug for UNIX systems

### DIFF
--- a/vtcalcs/src/lam_lib.c
+++ b/vtcalcs/src/lam_lib.c
@@ -256,7 +256,8 @@ void	lam ( float *pa )		/* a set of JAW+TNG+LIP+LRX */
 	ivt[  np].x = evt[np].x;
 	ivt[  np].y = evt[np].y - v_lip[2];	/* lower lip */
 
-	evt[++np].x = evt[np-1].x - v_lip[1];
+	++np;
+	evt[  np].x = evt[np-1].x - v_lip[1];
 	evt[  np].y = evt[np-1].y;
 	ivt[  np].x = evt[np].x;
 	ivt[  np].y = ivt[np-1].y;


### PR DESCRIPTION
On Windows, both the matlab version and vtcalcs.c produce the same output (formants) given the same input (AM inputs). However, the output values on Linux on UNIX systems (Linux and Mac) are different from the Windows/vtcalcs. output. 
I tracked down where the discrepancy starts, it seems to be in lam_lib.c from an increment bug with the index variable, np. 
 

